### PR TITLE
Add CLI options for serial port and mock mode

### DIFF
--- a/launcher_gui.py
+++ b/launcher_gui.py
@@ -34,6 +34,17 @@ class LauncherGUI:
         mock_serial: bool = True,
         cam_index: int | None = 1,          # None → auto-detect
     ) -> None:
+        """Initialize the interface.
+
+        Parameters
+        ----------
+        port:
+            Serial port for the Arduino.
+        mock_serial:
+            If ``True`` use a mock serial connection.
+        cam_index:
+            Webcam index or ``None`` to auto-detect.
+        """
         # -------- tkinter window --------
         self.root = tk.Tk()
         self.root.title("Ping-Pong Launcher")

--- a/main.py
+++ b/main.py
@@ -10,6 +10,8 @@ t / b / f : topspin / backspin / flat shot presets  [only with --spin]
 Run without flags for plain tracking + servo.
 Add --spin to enable wheel controls.
 Use --gui  to start the Tkinter interface instead of the CLI demo.
+Use --port to specify the Arduino serial port.
+Use --[no-]mock to enable or disable mock serial mode.
 """
 
 from __future__ import annotations
@@ -35,24 +37,33 @@ parser.add_argument(
     action="store_true",
     help="launch the Tkinter GUI",
 )
+parser.add_argument(
+    "--port",
+    default="COM5",
+    help="serial port for the Arduino",
+)
+parser.add_argument(
+    "--mock",
+    action=argparse.BooleanOptionalAction,
+    default=True,
+    help="use a mock serial connection",
+)
 args = parser.parse_args()
 
 # ------------------------------------------------ Config
 WEBCAM_INDEX = find_camera_index() or 0
 FRAME_W, FRAME_H, FPS = 640, 480, 30
-ARDUINO_PORT = "COM5"
-MOCK_SERIAL  = True
 WINDOW_NAME  = "Ping-Pong Servo Aimer"
 
 # ------------------------------------------------ Main
 def main() -> None:
     if args.gui:
         from launcher_gui import LauncherGUI
-        gui = LauncherGUI(port=ARDUINO_PORT, mock_serial=MOCK_SERIAL)
+        gui = LauncherGUI(port=args.port, mock_serial=args.mock)
         gui.run()
         return
 
-    ser = SerialController(ARDUINO_PORT, mock=MOCK_SERIAL)
+    ser = SerialController(args.port, mock=args.mock)
     ser.connect()
 
     # optional wheel controller


### PR DESCRIPTION
## Summary
- add `--port` and `--mock` command line options
- use CLI values when launching GUI or SerialController
- document parameters in `LauncherGUI.__init__`

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_685824a37a988330af59d3d5d91d728a