### PR TITLE
Add serial port auto-detection

### DIFF
--- a/launcher_gui.py
+++ b/launcher_gui.py
@@ -21,7 +21,7 @@ from servo_aim import ServoAimer, Mode
 from serial_controller import SerialController
 from gate_controller import GateController
 from wheel_controller import WheelController
-from utils import pad_square, find_camera_index
+from utils import pad_square, find_camera_index, find_serial_port
 
 
 class LauncherGUI:
@@ -30,7 +30,7 @@ class LauncherGUI:
     def __init__(
         self,
         *,
-        port: str = "COM5",
+        port: str | None = None,
         mock_serial: bool = True,
         cam_index: int | None = 1,          # None → auto-detect
     ) -> None:
@@ -40,6 +40,8 @@ class LauncherGUI:
         self.root.protocol("WM_DELETE_WINDOW", self._on_close)
 
         # -------- back-end objects ------
+        if port is None:
+            port = find_serial_port() or "COM5"
         self.serial = SerialController(port, mock=mock_serial)
         self.serial.connect()
 
@@ -212,7 +214,16 @@ class LauncherGUI:
 
 # Convenience entry-point
 def main() -> None:
-    LauncherGUI().run()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--port",
+        help="Arduino serial port; auto-detect if omitted",
+    )
+    args = parser.parse_args()
+
+    LauncherGUI(port=args.port).run()
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ t / b / f : topspin / backspin / flat shot presets  [only with --spin]
 Run without flags for plain tracking + servo.
 Add --spin to enable wheel controls.
 Use --gui  to start the Tkinter interface instead of the CLI demo.
+Use --port to specify the Arduino serial port.
 """
 
 from __future__ import annotations
@@ -20,7 +21,7 @@ from pose_tracker import PoseTracker
 from servo_aim import ServoAimer, Mode
 from serial_controller import SerialController
 from gate_controller import GateController
-from utils import pad_square, find_camera_index
+from utils import pad_square, find_camera_index, find_serial_port
 from collections import deque
 
 # ------------------------------------------------ Argument flag
@@ -35,12 +36,16 @@ parser.add_argument(
     action="store_true",
     help="launch the Tkinter GUI",
 )
+parser.add_argument(
+    "--port",
+    help="Arduino serial port; auto-detect if omitted",
+)
 args = parser.parse_args()
 
 # ------------------------------------------------ Config
 WEBCAM_INDEX = find_camera_index() or 0
 FRAME_W, FRAME_H, FPS = 640, 480, 30
-ARDUINO_PORT = "COM5"
+ARDUINO_PORT = args.port or find_serial_port() or "COM5"
 MOCK_SERIAL  = True
 WINDOW_NAME  = "Ping-Pong Servo Aimer"
 

--- a/utils.py
+++ b/utils.py
@@ -18,6 +18,7 @@ __all__ = [
     "map_to_servo_angle",
     "calculate_servo_point",
     "find_camera_index",
+    "find_serial_port",
 ]
 
 
@@ -90,6 +91,29 @@ def find_camera_index(max_index: int = 4) -> int | None:
             cap.release()
             return idx
         cap.release()
+    return None
+
+
+def find_serial_port(keyword: str = "Arduino") -> str | None:
+    """Return the first serial port whose description contains *keyword*.
+
+    Uses :func:`serial.tools.list_ports.comports` to scan connected serial
+    devices and returns the ``device`` value for the first port whose
+    ``description`` includes ``keyword`` (case-insensitive).  Returns ``None``
+    if no matching port is found.
+    """
+    try:
+        from serial.tools.list_ports import comports
+    except Exception:
+        return None
+
+    for info in comports():
+        try:
+            if keyword.lower() in info.description.lower():
+                return info.device
+        except Exception:
+            # Info objects may lack attributes depending on platform
+            continue
     return None
 
 


### PR DESCRIPTION
## Summary
- add `utils.find_serial_port` for Arduino detection
- use the new helper in `main.py` when `--port` is not given
- allow the GUI to auto-detect and add a `--port` option

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685824a53ab88330ab919dc974dfa7ba