### PR TITLE
Add GUI toggle for mock serial

### DIFF
--- a/launcher_gui.py
+++ b/launcher_gui.py
@@ -42,7 +42,8 @@ class LauncherGUI:
         port:
             Serial port for the Arduino.
         mock_serial:
-            If ``True`` use a mock serial connection.
+            If ``True`` use a mock serial connection. This can also be
+            toggled later from the GUI.
         cam_index:
             Webcam index or ``None`` to auto‑detect.
         """
@@ -79,6 +80,7 @@ class LauncherGUI:
         self.mode_var  = tk.StringVar(value=str(self.aimer.mode))
         self.spin_var  = tk.StringVar(value=self.wheels._preset.name)
         self.angle_var = tk.IntVar(value=0)
+        self.mock_var  = tk.BooleanVar(value=mock_serial)
 
         self._build_widgets()
 
@@ -133,6 +135,14 @@ class LauncherGUI:
         self.video_label = ttk.Label(frame)
         self.video_label.grid(row=7, column=0, columnspan=4, pady=10)
 
+        # --- serial mode toggle -------------------------------------------
+        ttk.Checkbutton(
+            frame,
+            text="Mock Serial",
+            variable=self.mock_var,
+            command=self._toggle_mock,
+        ).grid(row=8, column=0, columnspan=2, sticky="w")
+
     # ------------------------------------------------------------------
     # Button callbacks
     # ------------------------------------------------------------------
@@ -148,6 +158,13 @@ class LauncherGUI:
         self.wheels.set_spin(preset)
         self.spin_var.set(preset)
         print(f"[GUI] Spin -> {preset.upper()}")
+
+    def _toggle_mock(self) -> None:
+        """Callback to switch between mock and real serial mode."""
+        use_mock = self.mock_var.get()
+        self.serial.set_mock(use_mock)
+        state = "MOCK" if use_mock else "REAL"
+        print(f"[GUI] Serial mode -> {state}")
 
     # ------------------------------------------------------------------
     # Lifecycle controls

--- a/serial_controller.py
+++ b/serial_controller.py
@@ -37,6 +37,18 @@ class SerialController:
             self._ser.close()
             print("[Serial] Port closed.")
 
+    def set_mock(self, mock: bool) -> None:
+        """Switch between mock mode and real serial connection."""
+        if self.mock == mock:
+            return
+        # always close any existing connection before switching
+        self.close()
+        self.mock = mock
+        if not mock:
+            self.connect()
+        else:
+            print("[Serial] Running in MOCK mode -> nothing will be sent.")
+
     # ------------------------------------------------------------------
     # Convenience writers
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add ability to switch between mock serial and real Arduino connection from the Tk interface
- implement `SerialController.set_mock` to reconnect when mode changes

## Testing
- `python -m py_compile launcher_gui.py serial_controller.py`
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859257f787483308e5070e13608b036