### PR TITLE
Update camera selection defaults

### DIFF
--- a/launcher_gui.py
+++ b/launcher_gui.py
@@ -34,7 +34,7 @@ class LauncherGUI:
         *,
         port: str = "COM5",
         mock_serial: bool = True,
-        cam_index: int | None = 1,          # None → auto‑detect
+        cam_index: int | None = None,       # None → auto‑detect
     ) -> None:
         """Initialize the interface.
 
@@ -46,7 +46,7 @@ class LauncherGUI:
             If ``True`` use a mock serial connection. This can also be
             toggled later from the GUI.
         cam_index:
-            Webcam index or ``None`` to auto‑detect.
+            Webcam index or ``None`` to auto‑detect. Defaults to ``None``.
         """
         # -------- tkinter window --------
         self.root = tk.Tk()


### PR DESCRIPTION
## Summary
- default camera index to `None` so auto detection runs by default
- document that the camera index defaults to `None`

## Testing
- `pytest -q`
- `python -m py_compile launcher_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6859372d42cc83308c39135bfee58814